### PR TITLE
Update services section and fix images

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,9 @@
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import HeroSection from "../components/HeroSection";
-import ServicesCarousel from "../components/ServicesCarousel";
+import ServicesSection from "../components/ServicesSection";
 import BusinessStats from "../components/BusinessStats";
 import TestimonialsCarousel from "../components/TestimonialsCarousel";
-import styles from "./page.module.css";
 
 export default function HomePage() {
   return (
@@ -12,7 +11,7 @@ export default function HomePage() {
       <Header />
       <main>
         <HeroSection />
-        <ServicesCarousel />
+        <ServicesSection />
         <BusinessStats />
         <TestimonialsCarousel />
       </main>

--- a/src/components/BusinessStats.tsx
+++ b/src/components/BusinessStats.tsx
@@ -54,24 +54,28 @@ function useCountUp(target: number, duration: number) {
   return count;
 }
 
+function StatCard({ label, suffix, desc, icon, duration }: (typeof stats)[0]) {
+  const count = useCountUp(label, duration);
+  return (
+    <div className={styles.statCard}>
+      <FontAwesomeIcon icon={icon} className={styles.icon} />
+      <div className={styles.label}>
+        {count}
+        {suffix}
+      </div>
+      <div className={styles.desc}>{desc}</div>
+    </div>
+  );
+}
+
 export default function BusinessStats() {
   return (
     <section className={styles.statsSection}>
       <div className={styles.statsWrap}>
-        {stats.map((stat, i) => {
-          const count = useCountUp(stat.label, stat.duration);
-          return (
-            <div className={styles.statCard} key={i}>
-              <FontAwesomeIcon icon={stat.icon} className={styles.icon} />
-              <div className={styles.label}>
-                {count}
-                {stat.suffix}
-              </div>
-              <div className={styles.desc}>{stat.desc}</div>
-            </div>
-          );
-        })}
+        {stats.map((stat, i) => (
+          <StatCard key={i} {...stat} />
+        ))}
       </div>
     </section>
   );
-} 
+}

--- a/src/components/HeroCarousel.tsx
+++ b/src/components/HeroCarousel.tsx
@@ -6,7 +6,7 @@ export default function HeroCarousel() {
   return (
     <section className={styles.heroSection}>
       <div className={styles.bgWrap}>
-        <Image src="/crane-home.jpg" alt="Rental Crane" fill priority className={styles.bgImg} />
+        <Image src="/crane-home.png" alt="Rental Crane" fill priority className={styles.bgImg} />
         <div className={styles.gradientOverlay} />
         {/* Decorative SVG geometric shapes */}
         <svg className={styles.svg1} width="120" height="120" viewBox="0 0 120 120" fill="none"><circle cx="60" cy="60" r="60" fill="#2563eb22" /></svg>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,7 +1,5 @@
 import Image from "next/image";
 import styles from "./HeroSection.module.css";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTruckLoading } from "@fortawesome/free-solid-svg-icons";
 
 export default function HeroSection() {
   return (

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -3,19 +3,19 @@ import styles from './ServicesSection.module.css';
 
 const services = [
   {
-    title: 'Rental of Loading, Lifting & Construction',
-    img: '/crane-home.jpg',
+    title: 'Rental Cranes',
+    img: '/Crane1.png',
     desc: 'Professional crane rental and construction logistics for all project sizes. Modern fleet, expert operators.',
     main: true,
   },
   {
-    title: 'Cargo Transport by Light Truck',
-    img: '/crane1.jpg',
+    title: 'Light Trucks',
+    img: '/Light-Truck1.png',
     desc: 'Efficient cargo transport for small and medium loads across the UAE. Reliable and timely service.',
   },
   {
-    title: 'Cargo Transport by Heavy Truck',
-    img: '/crane2.jpg',
+    title: 'Heavy Trucks',
+    img: '/Heavy-Truck1.png',
     desc: 'Heavy-duty transport solutions for large cargo and construction materials. Safe and secure delivery.',
   },
 ];
@@ -25,7 +25,7 @@ export default function ServicesSection() {
     <section className={styles.servicesSection} id="services">
       <h2 className={styles.heading}>Our Services</h2>
       <div className={styles.cardsWrap}>
-        {services.map((service, i) => (
+        {services.map((service) => (
           <div
             key={service.title}
             className={service.main ? `${styles.card} ${styles.main}` : styles.card}


### PR DESCRIPTION
## Summary
- use correct images for services cards
- swap in ServicesSection on homepage
- fix missing image extension in HeroCarousel
- refactor BusinessStats and cleanup imports

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863d8dda4ac8329b0470964e0ed54b8